### PR TITLE
Relax requirements, make sure that numpy input array is contiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,25 @@ The wrapper was successfully tested on OSX (10.6/10.7), Ubuntu (11.04) and Arch 
 Requirements
 ------------
 
-* [numpy](numpy.scipy.org)==1.7.1
-* [scipy]()==0.12.0
-* [cython](cython.org)===0.19.1
-* [openblas](https://github.com/xianyi/OpenBLAS). Tested version is v0.2.5 and v0.2.6 (not necessary for OSX).
+* [numpy](numpy.scipy.org)>=1.7.1
+* [scipy](http://www.scipy.org/)>=0.12.0
+* [cython](cython.org)>=0.19.1
+* [cblas](http://www.netlib.org/blas/) or [openblas](https://github.com/xianyi/OpenBLAS). Tested version is v0.2.5 and v0.2.6 (not necessary for OSX).
 
 Installation
 ------------
 
-`pip install tsne`
+You can install the package from [PyPI](https://pypi.python.org/pypi):
+
+```
+pip install tsne
+```
+
+Or directly from the Github repository:
+
+```
+pip install git+https://github.com/danielfrg/tsne.git
+```
 
 Usage
 -----
@@ -44,4 +54,6 @@ X_2d = bh_sne(X)
 
 More Information
 ----------------
-See *Barnes-Hut-SNE*, L.J.P. van der Maaten. It is available on [arxiv](http://arxiv.org/abs/1301.3342).
+
+See *Barnes-Hut-SNE* (2013), L.J.P. van der Maaten. It is available on [arxiv](http://arxiv.org/abs/1301.3342).
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Cython==0.19.1
-numpy==1.7.1
-scipy==0.12.0
+Cython>=0.19.1
+numpy>=1.7.1
+scipy>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ else:
                    include_dirs=[numpy.get_include(), '/usr/local/include', 'tsne/bh_sne_src/'],
                    library_dirs=['/usr/local/lib'],
                    extra_compile_args=['-msse2', '-O3', '-fPIC', '-w'],
-                   extra_link_args=['-lopenblas'],
+                   extra_link_args=['-lcblas'],
                    language='c++')]
 
 setup(
@@ -39,8 +39,9 @@ setup(
     cmdclass={'build_ext': build_ext},
     long_description=open('README.txt').read(),
     install_requires=[
-        'Cython==0.19.1',
-        'numpy==1.7.1',
-        'scipy==0.12.0'
+        'Cython>=0.19.1',
+        'numpy>=1.7.1',
+        'scipy>=0.12.0'
     ],
 )
+

--- a/tsne/bh_sne.pyx
+++ b/tsne/bh_sne.pyx
@@ -20,7 +20,8 @@ cdef class BH_SNE:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def run(self, X, N, D, d, perplexity, theta):
-        cdef np.ndarray[np.float64_t, ndim=2, mode='c'] _X = X
+        cdef np.ndarray[np.float64_t, ndim=2, mode='c'] _X = np.ascontiguousarray(X)
         cdef np.ndarray[np.float64_t, ndim=2, mode='c'] Y = np.zeros((N, d), dtype=np.float64)
         self.thisptr.run(&_X[0,0], N, D, &Y[0,0], d, perplexity, theta)
         return Y
+


### PR DESCRIPTION
Hi,
It took a while, but here are some proposed changes.

**Numpy, Scipy, Cython dependencies: use >= instead of == for version comparison**

Right now, you request the exact same version of those libraries that you were using. However, there is no reason to assume that the tsne library will break with future releases of numpy. If I, for instance, `pip install` tsne, it will try and install your library version instead of the one I have (1.8.0) - this doesn't make any sense.

**BLAS: cblas is required, not OpenBLAS**

There is a couple of version of BLAS. The old Fortran one (blas), the one with C bindings (cblas) and an open source implementation that supports threading (OpenBLAS). tsne makes use of cblas headers, which are provided by cblas _or_ OpenBLAS. Since cblas is a subset of OpenBLAS (and OpenBLAS provides .so files for cblas), it makes more sense to include cblas as a dependency instead of OpenBLAS

**Numpy arrays in memory**

You don't know for sure if the input array to tsne is contiguous in memory. Subsetting Numpy arrays can lead to discontiguous objects, which you don't want to pass C code (otherwise you will get illegal memory operations).
