### PR TITLE
Changes vecLib.framework location for OSX 10.9 and 10.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,26 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import sys
+import platform
 
 DESCRIPTION = 'TSNE implementations for python'
-
+MAVERICKS_VERSION = '10.9'
+YOSEMITE_VERSION = '10.10'
 
 if sys.platform == 'darwin':
+    # Get OSX version number as string
+    v = platform.mac_ver()[0]
+    if v.startswith(MAVERICKS_VERSION) or v.startswith(YOSEMITE_VERSION):
+      blas_location = ('-I/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks' +
+                       '/vecLib.framework/Versions/Current/Headers/')
+    else:
+      blas_location = '-I/System/Library/Frameworks/vecLib.framework/Headers'
+
     ext_modules = [Extension(
                    name='bh_sne',
                    sources=['tsne/bh_sne_src/quadtree.cpp', 'tsne/bh_sne_src/tsne.cpp', 'tsne/bh_sne.pyx'],
                    include_dirs=[numpy.get_include(), 'tsne/bh_sne_src/'],
-                   extra_compile_args=['-I/System/Library/Frameworks/vecLib.framework/Headers'],
+                   extra_compile_args=[blas_location],
                    extra_link_args=['-Wl,-framework', '-Wl,Accelerate', '-lcblas'],
                    language='c++')]
 else:


### PR DESCRIPTION
Starting in OSX 10.9, Apple has moved the vecLib framework under
the Accelerate framework. This patch accounts for that change
in the setup.py. Without this patch, it is difficult to build the package
using pip.

See Apple's developer documentation for details:
https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man7/Accelerate.7.html
