### PR TITLE
Build and Install on OS X without Anaconda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from distutils.extension import Extension
 import versioneer
 import numpy
 from Cython.Distutils import build_ext
-
+from Cython.Build import cythonize
 
 if sys.platform == 'darwin':
     # OS X
@@ -26,12 +26,13 @@ if sys.platform == 'darwin':
         extra_compile_args=['-I/System/Library/Frameworks/vecLib.framework/Headers']
 
     ext_modules = [Extension(
-                   name='bh_sne',
+                   name='tsne/bh_sne',
                    sources=['tsne/bh_sne_src/quadtree.cpp', 'tsne/bh_sne_src/tsne.cpp', 'tsne/bh_sne.pyx'],
                    include_dirs=[numpy.get_include(), 'tsne/bh_sne_src/'],
                    extra_compile_args=extra_compile_args,
                    extra_link_args=['-Wl,-framework', '-Wl,Accelerate', '-lcblas'],
                    language='c++')]
+    ext_modules = cythonize(ext_modules)
 else:
     # LINUX
     ext_modules = [Extension(

--- a/tsne/bh_sne.pyx
+++ b/tsne/bh_sne.pyx
@@ -1,3 +1,4 @@
+# distutils: language = c++
 import numpy as np
 cimport numpy as np
 cimport cython


### PR DESCRIPTION
The current setup.py fails to install on OS X El Capitan (and perhaps other versions) because we didn't cythonize the .pyx files.

This pull request fixes that issue.