### PR TITLE
Compile with "-lsatlas" instead of "-lcblas" on Red Hat family distributions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ else:
                    include_dirs=[numpy.get_include(), '/usr/local/include', 'tsne/bh_sne_src/'],
                    library_dirs=['/usr/local/lib'],
                    extra_compile_args=['-msse2', '-O3', '-fPIC', '-w'],
-                   extra_link_args=['-lcblas'],
+                   extra_link_args=extra_link_args,
                    language='c++')]
 
 ext_modules = cythonize(ext_modules)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,10 @@ if sys.platform == 'darwin':
                    extra_link_args=['-Wl,-framework', '-Wl,Accelerate', '-lcblas'],
                    language='c++')]
 else:
+    extra_link_args = ['-lcblas']
+    if 'fedora' in platform.platform():
+        extra_link_args = ['-lsatlas']
+    
     # LINUX
     ext_modules = [Extension(name='bh_sne',
                    sources=['tsne/bh_sne_src/quadtree.cpp', 'tsne/bh_sne_src/tsne.cpp', 'tsne/bh_sne.pyx'],

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ if sys.platform == 'darwin':
                    language='c++')]
 else:
     extra_link_args = ['-lcblas']
-    if 'fedora' in platform.platform():
+    dist = platform.linux_distribution(full_distribution_name=0)[0]
+    redhat_dists = set(["redhat", "fedora", "centos"])
+    if dist in redhat_dists:
         extra_link_args = ['-lsatlas']
     
     # LINUX


### PR DESCRIPTION
<code>pip install tsne</code> produces the below error on Fedora. As discussed [here](https://github.com/dmlc/mxnet/issues/1442#issuecomment-182171637), Red Hat family distributions need to use "-lsatlas" instead of "-lcblas" when linking to ATLAS during compilation.

> > sudo pip install tsne  
> You are using pip version 7.1.0, however version 8.1.2 is available.
> You should consider upgrading via the 'pip install --upgrade pip' command.
> Collecting tsne
>   Using cached tsne-0.1.5.tar.gz
> Requirement already satisfied (use --upgrade to upgrade): Cython>=0.19.1 in /usr/lib64/python2.7/site-packages (from tsne)
> Requirement already satisfied (use --upgrade to upgrade): numpy>=1.7.1 in /usr/lib/python2.7/site-packages (from tsne)
> Requirement already satisfied (use --upgrade to upgrade): scipy>=0.12.0 in /usr/lib/python2.7/site-packages (from tsne)
> Building wheels for collected packages: tsne
>   Running setup.py bdist_wheel for tsne
>   Complete output from command /usr/bin/python -c "import setuptools;**file**='/tmp/pip-build-oWvvOv/tsne/setup.py';exec(compile(open(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" bdist_wheel -d /tmp/tmpTv8f_8pip-wheel-:
>   /usr/lib/python2.7/site-packages/setuptools/dist.py:285: UserWarning: Normalizing 'v0.1.5' to '0.1.5'
>     normalized_version,
>   !!!!!!!!!!!!! ['tsne', 'tsne.tests']
>   running bdist_wheel
>   running build
>   running build_py
>   creating build
>   creating build/lib.linux-x86_64-2.7
>   creating build/lib.linux-x86_64-2.7/tsne
>   copying tsne/_version.py -> build/lib.linux-x86_64-2.7/tsne
>   copying tsne/__init__.py -> build/lib.linux-x86_64-2.7/tsne
>   creating build/lib.linux-x86_64-2.7/tsne/tests
>   copying tsne/tests/test_iris.py -> build/lib.linux-x86_64-2.7/tsne/tests
>   copying tsne/tests/**init**.py -> build/lib.linux-x86_64-2.7/tsne/tests
>   UPDATING build/lib.linux-x86_64-2.7/tsne/_version.py
>   set build/lib.linux-x86_64-2.7/tsne/_version.py to 'v0.1.5'
>   running build_ext
>   building 'bh_sne' extension
>   creating build/temp.linux-x86_64-2.7
>   creating build/temp.linux-x86_64-2.7/tsne
>   creating build/temp.linux-x86_64-2.7/tsne/bh_sne_src
>   gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/lib/python2.7/site-packages/numpy/core/include -I/usr/local/include -Itsne/bh_sne_src/ -I/usr/include/python2.7 -c tsne/bh_sne.cpp -o build/temp.linux-x86_64-2.7/tsne/bh_sne.o -msse2 -O3 -fPIC -w
>   gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/lib/python2.7/site-packages/numpy/core/include -I/usr/local/include -Itsne/bh_sne_src/ -I/usr/include/python2.7 -c tsne/bh_sne_src/quadtree.cpp -o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/quadtree.o -msse2 -O3 -fPIC -w
>   gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/lib/python2.7/site-packages/numpy/core/include -I/usr/local/include -Itsne/bh_sne_src/ -I/usr/include/python2.7 -c tsne/bh_sne_src/tsne.cpp -o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/tsne.o -msse2 -O3 -fPIC -w
>   g++ -pthread -shared -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld build/temp.linux-x86_64-2.7/tsne/bh_sne.o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/quadtree.o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/tsne.o -L/usr/local/lib -L/usr/lib64 -lpython2.7 -o build/lib.linux-x86_64-2.7/bh_sne.so -lcblas
>   /bin/ld: cannot find -lcblas
>   collect2: error: ld returned 1 exit status
>   error: command 'g++' failed with exit status 1
> ---
> 
>   Failed building wheel for tsne
> Failed to build tsne
> Installing collected packages: tsne
>   Running setup.py install for tsne
>     Complete output from command /usr/bin/python -c "import setuptools, tokenize;**file**='/tmp/pip-build-oWvvOv/tsne/setup.py';exec(compile(getattr(tokenize, 'open', open)(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" install --record /tmp/pip-3INCRC-record/install-record.txt --single-version-externally-managed --compile:
>     /usr/lib/python2.7/site-packages/setuptools/dist.py:285: UserWarning: Normalizing 'v0.1.5' to '0.1.5'
>       normalized_version,
>     !!!!!!!!!!!!! ['tsne', 'tsne.tests']
>     running install
>     running build
>     running build_py
>     UPDATING build/lib.linux-x86_64-2.7/tsne/_version.py
>     set build/lib.linux-x86_64-2.7/tsne/_version.py to 'v0.1.5'
>     running build_ext
>     building 'bh_sne' extension
>     gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/lib/python2.7/site-packages/numpy/core/include -I/usr/local/include -Itsne/bh_sne_src/ -I/usr/include/python2.7 -c tsne/bh_sne.cpp -o build/temp.linux-x86_64-2.7/tsne/bh_sne.o -msse2 -O3 -fPIC -w
>     gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/lib/python2.7/site-packages/numpy/core/include -I/usr/local/include -Itsne/bh_sne_src/ -I/usr/include/python2.7 -c tsne/bh_sne_src/quadtree.cpp -o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/quadtree.o -msse2 -O3 -fPIC -w
>     gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/lib/python2.7/site-packages/numpy/core/include -I/usr/local/include -Itsne/bh_sne_src/ -I/usr/include/python2.7 -c tsne/bh_sne_src/tsne.cpp -o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/tsne.o -msse2 -O3 -fPIC -w
>     g++ -pthread -shared -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld build/temp.linux-x86_64-2.7/tsne/bh_sne.o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/quadtree.o build/temp.linux-x86_64-2.7/tsne/bh_sne_src/tsne.o -L/usr/local/lib -L/usr/lib64 -lpython2.7 -o build/lib.linux-x86_64-2.7/bh_sne.so -lcblas
>     /bin/ld: cannot find -lcblas
>     collect2: error: ld returned 1 exit status
>     error: command 'g++' failed with exit status 1
> 
> ```
> ----------------------------------------
> ```
> 
> Command "/usr/bin/python -c "import setuptools, tokenize;**file**='/tmp/pip-build-oWvvOv/tsne/setup.py';exec(compile(getattr(tokenize, 'open', open)(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" install --record /tmp/pip-3INCRC-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-oWvvOv/tsne
