### PR TITLE
conda-forge update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install -c conda-forge numpy cython scipy pytest scikit-learn distro
+  - conda install -c conda-forge numpy cython scipy pytest scikit-learn
   - python setup.py install
   - source deactivate
 

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,10 @@ if sys.platform == 'darwin':
                    language='c++')]
 else:
     extra_link_args = ['-lcblas']
-    dist = distro.linux_distribution()[0].lower()
-    redhat_dists = set(["redhat", "fedora", "centos"])
-    if dist in redhat_dists:
-        extra_link_args = ['-lsatlas']
+    # dist = distro.linux_distribution()[0].lower()
+    # redhat_dists = set(["redhat", "fedora", "centos"])
+    # if dist in redhat_dists:
+    #     extra_link_args = ['-lsatlas']
 
     # LINUX
     ext_modules = [Extension(name='bh_sne',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ To upload a new version:
 """
 
 
-import distro
 import os
 import sys
 import platform
@@ -53,10 +52,6 @@ if sys.platform == 'darwin':
                    language='c++')]
 else:
     extra_link_args = ['-lcblas']
-    # dist = distro.linux_distribution()[0].lower()
-    # redhat_dists = set(["redhat", "fedora", "centos"])
-    # if dist in redhat_dists:
-    #     extra_link_args = ['-lsatlas']
 
     # LINUX
     ext_modules = [Extension(name='bh_sne',


### PR DESCRIPTION
I've removed the addition of `[-lsatlas]` to `extra_link_args` when encountering "redhat", "fedora" or "centos" linux distributions for being handled within conda.

This previously required `distro`, which has now been removed.